### PR TITLE
fix interrupt enable setting

### DIFF
--- a/apds9930/__init__.py
+++ b/apds9930/__init__.py
@@ -293,7 +293,7 @@ class APDS9930(APDS9930_I2C_Base):
         self.proximity_gain = DEFAULT_PGAIN
         self.led_drive = DEFAULT_PDRIVE
         self.proximity_diode = DEFAULT_PDIODE
-        self.proximity_interrupt = interrupt
+        self.enable_proximity_interrupt = interrupt
         self.power = True
         self.proximity_sensor = True
 


### PR DESCRIPTION
in enable_proximity_sensor() , it says "If interrupt is True, proximity interrupts will also be enabled". But current implementation is to clear interrupt. it do not enable interrupt